### PR TITLE
Added Perfect Blackfathom Pearl to Aku'mai loot table #4

### DIFF
--- a/AtlasLootClassic/Data/Token.lua
+++ b/AtlasLootClassic/Data/Token.lua
@@ -239,6 +239,9 @@ TOKEN_DATA.CLASSIC = {
 				22667, 22668, 22657, 22659, 22678, 22656, type = 4 }, -- Insignia of the Dawn
 	[22524] = 22523, -- Insignia of the Crusade
 
+	-- BFD Raid
+	[209693] = { 211449, 211450, 211451, type = 3 }, -- Perfect Blackfathom Pearl
+	
 	-- Naxxramas
 	[22520] = { 23207, 23206, type = 3 }, -- The Phylactery of Kel'Thuzad
 

--- a/AtlasLootClassic_DungeonsAndRaids/data.lua
+++ b/AtlasLootClassic_DungeonsAndRaids/data.lua
@@ -1079,6 +1079,7 @@ data["BlackfathomDeepsRaid"] = {
 				{ 4,  209692 }, -- Sentinel Pauldrons
 				{ 5,  209685 }, -- Ancient Moss Cinch
 				{ 6,  209690 }, -- Shadowscale Coif
+				{ 8,  209693 }, -- Perfect Blackfathom Pearl
 				{ 16, 209691 }, -- Vampiric Boot Knife
 				{ 17, 211456 }, -- Dagger of Willing Sacrifice
 				{ 18, 209688 }, -- Bael Modan Blunderbuss


### PR DESCRIPTION
Alliance version:
https://www.wowhead.com/classic/item=209693/perfect-blackfathom-pearl

![image](https://github.com/Corazu/AtlasLootClassic/assets/3531992/53cb7ce9-f192-4401-9174-d38c092416e5)
